### PR TITLE
Recursive file addition + command line arguments

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -15,25 +15,21 @@ An example of `.plunk_config.json`:
 }
 ```
 
-Usage (while in target directory):
+Usage
 ```
-plunk 
+plunk --dir path/to/dir --des "A string describing the plunk" --tags "comma,separated,tags"
 ```
-
-Usage (with explicit directory)
-```
-plunk path/to/dir
-```
+This will upload all files in `path/to/dir` recursively, with the given description and tags.
+> Note: if you do not specify `--dir`, it will use the current working directory.
 
 Exclusions:
 - Ignores files starting with a dot `'.'`
-- Doesn't allow subdirectories
 - Doesn't allow files with MIME other than `text/*` or `*/json` or `*/javascript` (.html .js .css are fine)
 
 Gotchas:
 
 - Saves current plunk metadata in the file `.plunk`, uses it to update the plunk properly
-- A once-created plunk is bound to current directory name. When you copy it into a new directory (or rename), `plunk` will create a brand-new plunk. 
-I found this behavior helpful, because when I clone an existing directory into a new example, 
-it makes me sure I will not overwrite an existing plunk. 
-
+- A once-created plunk is bound to current directory name. When you copy it into a new directory (or rename), `plunk` will create a brand-new plunk.
+I found this behavior helpful, because when I clone an existing directory into a new example,
+it makes me sure I will not overwrite an existing plunk.
+- The `--tags` flag only works when creating a new plunk, not updating an existing one

--- a/bin/plunk
+++ b/bin/plunk
@@ -7,8 +7,11 @@ var PlnkrApi = require('../plnkrApi').PlnkrApi;
 var readPlunkContent = require('../readPlunkContent');
 var writePlunk = require('../writePlunk');
 var _ = require('lodash');
+var argv = require('yargs').argv;
 
-var dir = process.argv[2] || process.cwd();
+var dir = argv.dir || process.cwd(),
+    description = argv.des,
+    tags = argv.tags ? argv.tags.split(',') : undefined;
 
 var plunkContent = readPlunkContent(dir);
 
@@ -48,8 +51,8 @@ function populateOldPlunk(callback) {
 function createPlunk(callback) {
 
   var form = {
-    description: '',
-    tags: [],
+    description: description || '',
+    tags: tags || [],
     files: _.cloneDeep(plunkContent.files),
     private: true
   };
@@ -61,7 +64,7 @@ function createPlunk(callback) {
 function updatePlunk(callback) {
 
   var form = {
-    description: '',
+    description: description || '',
     tags: {},
     files: _.cloneDeep(plunkContent.files)
   };
@@ -94,7 +97,3 @@ async.waterfall([
   if (err) console.error(err);
   else console.log("http://plnkr.co/edit/" + plunk.id);
 });
-
-
-
-

--- a/bin/plunk
+++ b/bin/plunk
@@ -95,5 +95,5 @@ async.waterfall([
   _.partial(writePlunk, dir)
 ], function(err, plunk) {
   if (err) console.error(err);
-  else console.log("http://plnkr.co/edit/" + plunk.id);
+  else console.log("Plunk URL: http://plnkr.co/edit/" + plunk.id);
 });

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "lodash": "*",
     "mime": "*",
     "nconf": "*",
-    "winston": "*"
+    "winston": "*",
+    "yargs": "*"
   },
   "preferGlobal": true,
   "bin": {

--- a/readPlunkContent.js
+++ b/readPlunkContent.js
@@ -4,7 +4,6 @@ var mime = require('mime');
 var walkSync = require('./utils/walkSync');
 
 function readPlunkContent(dir) {
-  console.log(dir)
   var parentDir = dir + '/';
 
   var files = walkSync(parentDir, dir, []);

--- a/readPlunkContent.js
+++ b/readPlunkContent.js
@@ -1,10 +1,13 @@
 var fs = require('fs');
 var path = require('path');
 var mime = require('mime');
+var walkSync = require('./utils/walkSync');
 
 function readPlunkContent(dir) {
+  console.log(dir)
+  var parentDir = dir + '/';
 
-  files = fs.readdirSync(dir);
+  var files = walkSync(parentDir, dir, []);
 
   files = files.filter(function(file) {
     if (file[0] == ".") return false;
@@ -30,10 +33,6 @@ function readPlunkContent(dir) {
   files.forEach(function(file) {
 
     var filePath = path.join(dir, file);
-    if (fs.statSync(filePath).isDirectory()) {
-      console.error("WARNING: skipped directory: " + file);
-      return;
-    }
 
     var type = mime.lookup(file).split('/');
     if (type[0] != 'text' && type[1] != 'json' && type[1] != 'javascript' && type[1] != 'mp2t') {
@@ -41,13 +40,11 @@ function readPlunkContent(dir) {
       return;
     }
 
-
     filesForPlunk[file] = {
       filename: file,
       content: fs.readFileSync(path.join(dir, file), 'utf-8')
     };
   });
-
 
   return {
     plunk: plunk,

--- a/utils/requestJson.js
+++ b/utils/requestJson.js
@@ -21,7 +21,9 @@ function makeMethod(method) {
     if (!options.json) options.json = true;
 
     return request[method](options, function(error, response, body) {
-      log.debug(method, options, error, response.statusCode, body);
+      if (body.invalid)
+        log.debug(body.invalid)
+
       callback(error, response, body);
     });
   }

--- a/utils/walkSync.js
+++ b/utils/walkSync.js
@@ -1,0 +1,18 @@
+function walkSync(parentDir, dir, filelist) {
+  var fs = fs || require('fs'),
+      files = fs.readdirSync(dir);
+
+  filelist = filelist || [];
+  files.forEach(function(file) {
+    if (fs.statSync(dir + '/' + file).isDirectory()) {
+      filelist = walkSync(parentDir, dir + '/' + file, filelist);
+    }
+    else {
+      var dirName = dir.split(parentDir)[1];
+      dirName ? filelist.push(dirName + '/' + file) : filelist.push(file);
+    }
+  });
+  return filelist;
+};
+
+module.exports = walkSync;


### PR DESCRIPTION
This update allows every valid file within every subdirectory of the provided directory to be added to the plunk. It uses Plunker's naming convention to accomplish this (i.e. if `app.js` is in the `src` directory, the actual name of the file uploaded to plunker becomes `src/app.js`).

I also made the directory a command line argument (`--dir`) as well as added arguments for description (`--des`) and tags (`--tags`).

These items helped me out quite a bit for my development so I created a pull request to see if they were something you wanted to add in. Thanks!